### PR TITLE
Fix Reflect.deleteProperty() editor Run Error

### DIFF
--- a/live-examples/js-examples/reflect/reflect-deleteproperty.html
+++ b/live-examples/js-examples/reflect/reflect-deleteproperty.html
@@ -11,7 +11,7 @@ console.log(object1.property1);
 var array1 = [1, 2, 3, 4, 5];
 Reflect.deleteProperty(array1, '3');
 
-console.log(array1);
-// expected output: Array [1, 2, 3, , 5]
+console.log('Array ' + '[' + array1.toString().replace(/,/g, ', ') + ']');
+// expected output: "Array [1, 2, 3, , 5]"
 </code>
 </pre>


### PR DESCRIPTION
From Reflect.deleteProperty(), the second sample result [1,2,3,,5] cause the runtime editor error,
I use toString to change the type and show the correct result, is that OK ?

before:

<img width="867" alt="2018-02-05 4 09 26" src="https://user-images.githubusercontent.com/4027049/35794406-8ef1217a-0a90-11e8-87fb-dfcc9de993e6.png">

after:

<img width="707" alt="2018-02-05 4 12 02" src="https://user-images.githubusercontent.com/4027049/35794418-95645a54-0a90-11e8-98db-fb07a6bb2159.png">
